### PR TITLE
Chore/protractor peer dep

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,18 @@
+parser: 'babel-eslint'
+rules:
+  indent:
+    - 2
+    - 2
+  quotes:
+    - 2
+    - single
+  linebreak-style:
+    - 2
+    - unix
+  semi:
+    - 2
+    - always
+env:
+  es6: true
+  node: true
+extends: 'eslint:recommended'

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,8 +1,0 @@
-{
-  "quotmark": "single",
-  "undef": true,
-  "unused": true,
-  "maxlen": 100,
-  "node": true,
-  "esnext": true
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.2
+##### Fixes
+* Add `protractor` as a `< 2.2.0` `peerDependency` to indicate that `1.x` isn't compatible with `protractor` `2.2.0` and above.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "url": "https://github.com/Updater/protractor-fail-fast/issues"
   },
   "homepage": "https://github.com/Updater/protractor-fail-fast",
+  "peerDependencies": {
+    "protractor": "< 2.2.0"
+  },
   "dependencies": {
     "jasmine-fail-fast": "~2.0.0"
   },


### PR DESCRIPTION
Add `protractor` as a `< 2.2.0` `peerDependency` to indicate that `1.x` isn't compatible with `protractor` `2.2.0` and above.