### PR TITLE
Fix plugin not working due to missing `module.exports`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-  "presets": ["env"]
+  "presets": ["env"],
+  "plugins": [
+      "add-module-exports"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.24.0",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-env": "^1.2.1",
     "mkdirp": "^0.5.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -258,6 +258,10 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-add-module-exports@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.2.1.tgz#9ae9a1f4a8dc67f0cdec4f4aeda1e43a5ff65e25"
+
 babel-plugin-check-es2015-constants@^6.3.13:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"


### PR DESCRIPTION
Upgrading from Babel 5 to 6 broke the default commonjs export that Protractor relies on for importing plugins.

Using the `add-module-exports` plugin to emulate Babel 5 behavior in this regard.