### PR TITLE
Wrap the unlink in a try...catch

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,5 +57,11 @@ function createFailFile() {
 }
 
 function deleteFailFile() {
-  unlinkSync(FAIL_FILE);
+  try {
+    unlinkSync(FAIL_FILE);
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      throw err;
+    }
+  }
 }


### PR DESCRIPTION
The commit message describes the change.

**tl;dr** The vanilla `unlink` freaks out and starts throwing up all over the place if the file does not exist. This PR deals with that not happening.